### PR TITLE
Clean test assets using make

### DIFF
--- a/Makefile.frag
+++ b/Makefile.frag
@@ -30,3 +30,7 @@ show-install-instructions:
 
 findphp:
 	@echo $(PHP_EXECUTABLE)
+
+clean-tests:
+	rm -f tests/*.diff tests/*.exp tests/*.log tests/*.out tests/*.php tests/*.sh
+


### PR DESCRIPTION
Added `make clean-test`. This remove test asset like diff files and logs from the tests folder.